### PR TITLE
Pass the id instead of the payment number

### DIFF
--- a/src/models/m_payment_mollie_api.erl
+++ b/src/models/m_payment_mollie_api.erl
@@ -374,7 +374,7 @@ handle_payment_sync(ThisPaymentJSON, Context) ->
                         ],
                         Context),
                     % Simulate the webhook call
-                    handle_payment_update(FirstPaymentNr, FirstPayment, ThisPaymentJSON, Context);
+                    handle_payment_update(FirstPaymentId, FirstPayment, ThisPaymentJSON, Context);
                 PSP ->
                     ?LOG_ERROR(#{
                         in => zotonic_mod_payment_mollie,


### PR DESCRIPTION
Changed passing the number instead of the id. I think this fixes the problem, but I'm not entirely sure.